### PR TITLE
changed variable name, default is 0

### DIFF
--- a/pkg/vcfg/types.go
+++ b/pkg/vcfg/types.go
@@ -420,7 +420,7 @@ type StdoutMode int
 
 // ..
 const (
-	StdoutModeUnspecified StdoutMode = iota
+	StdoutModeDefault StdoutMode = iota
 	StdoutModeStandard
 	StdoutModeScreenOnly
 	StdoutModeSerialOnly


### PR DESCRIPTION
default output mode is 0 in vinitd and kernel vtty device. renamed the variable to better reflect that.