### PR TITLE
Added automatic naming of virtualizers

### DIFF
--- a/cmd/vorteil/run.go
+++ b/cmd/vorteil/run.go
@@ -29,7 +29,7 @@ import (
 	"github.com/vorteil/vorteil/pkg/vpkg"
 )
 
-func runFirecracker(pkgReader vpkg.Reader, cfg *vcfg.VCFG) error {
+func runFirecracker(pkgReader vpkg.Reader, cfg *vcfg.VCFG, name string) error {
 	if runtime.GOOS != "linux" {
 		return errors.New("firecracker is only available on linux")
 	}
@@ -102,10 +102,10 @@ func runFirecracker(pkgReader vpkg.Reader, cfg *vcfg.VCFG) error {
 		return err
 	}
 
-	return run(virt, f.Name(), cfg)
+	return run(virt, f.Name(), cfg, name)
 }
 
-func runHyperV(pkgReader vpkg.Reader, cfg *vcfg.VCFG) error {
+func runHyperV(pkgReader vpkg.Reader, cfg *vcfg.VCFG, name string) error {
 	if runtime.GOOS != "windows" {
 		return errors.New("hyper-v is only available on windows system")
 	}
@@ -173,10 +173,10 @@ func runHyperV(pkgReader vpkg.Reader, cfg *vcfg.VCFG) error {
 		return err
 	}
 
-	return run(virt, f.Name(), cfg)
+	return run(virt, f.Name(), cfg, name)
 }
 
-func runVirtualBox(pkgReader vpkg.Reader, cfg *vcfg.VCFG) error {
+func runVirtualBox(pkgReader vpkg.Reader, cfg *vcfg.VCFG, name string) error {
 	if !virtualbox.Allocator.IsAvailable() {
 		return errors.New("virtualbox not found installed on system")
 	}
@@ -239,10 +239,10 @@ func runVirtualBox(pkgReader vpkg.Reader, cfg *vcfg.VCFG) error {
 		return err
 	}
 
-	return run(virt, f.Name(), cfg)
+	return run(virt, f.Name(), cfg, name)
 }
 
-func runQEMU(pkgReader vpkg.Reader, cfg *vcfg.VCFG) error {
+func runQEMU(pkgReader vpkg.Reader, cfg *vcfg.VCFG, name string) error {
 
 	if !qemu.Allocator.IsAvailable() {
 		return errors.New("qemu not installed on system")
@@ -257,7 +257,6 @@ func runQEMU(pkgReader vpkg.Reader, cfg *vcfg.VCFG) error {
 		log.Errorf("%v", err)
 		os.Exit(1)
 	}
-
 	f, err := ioutil.TempFile(parent, "vorteil.disk")
 	if err != nil {
 		log.Errorf("%v", err)
@@ -304,19 +303,20 @@ func runQEMU(pkgReader vpkg.Reader, cfg *vcfg.VCFG) error {
 		return err
 	}
 
-	return run(virt, f.Name(), cfg)
+	return run(virt, f.Name(), cfg, name)
 
 }
 
-func run(virt virtualizers.Virtualizer, diskpath string, cfg *vcfg.VCFG) error {
+func run(virt virtualizers.Virtualizer, diskpath string, cfg *vcfg.VCFG, name string) error {
 
 	// Gather home directory for firecracker storage path
 	home, err := homedir.Dir()
 	if err != nil {
 		return err
 	}
+
 	_ = virt.Prepare(&virtualizers.PrepareArgs{
-		Name:      "vorteil-vm",
+		Name:      fmt.Sprintf("%s-%s", name, randstr.Hex(4)),
 		PName:     virt.Type(),
 		Start:     true,
 		Config:    cfg,

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module github.com/vorteil/vorteil
 go 1.14
 
 require (
-	code.cloudfoundry.org/bytefmt v0.0.0-20200131002437-cf55d5288a48 // indirect
-	github.com/Microsoft/hcsshim v0.8.9 // indirect
 	cloud.google.com/go/storage v1.8.0
+	code.cloudfoundry.org/bytefmt v0.0.0-20200131002437-cf55d5288a48 // indirect
 	github.com/Azure/azure-sdk-for-go v42.3.0+incompatible
 	github.com/Azure/azure-storage-blob-go v0.8.0
 	github.com/Azure/go-autorest/autorest v0.10.2
 	github.com/Azure/go-autorest/autorest/azure/auth v0.4.2
+	github.com/Microsoft/hcsshim v0.8.9 // indirect
 	github.com/alessio/shellescape v1.2.2
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2
 	github.com/aws/aws-sdk-go v1.31.6
@@ -43,6 +43,7 @@ require (
 	github.com/heroku/docker-registry-client v0.0.0-20190909225348-afc9e1acc3d5
 	github.com/imdario/mergo v0.3.11
 	github.com/inconshreveable/log15 v0.0.0-20200109203555-b30bc20e4fd1 // indirect
+	github.com/kennygrant/sanitize v1.2.4
 	github.com/klauspost/compress v1.11.0
 	github.com/krolaw/dhcp4 v0.0.0-20190909130307-a50d88189771
 	github.com/mattn/go-colorable v0.1.7
@@ -73,8 +74,8 @@ require (
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
-	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
 	google.golang.org/api v0.25.0
+	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
 	gopkg.in/yaml.v2 v2.3.0
 	gotest.tools/v3 v3.0.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -611,6 +611,8 @@ github.com/juju/errors v0.0.0-20180806074554-22422dad46e1/go.mod h1:W54LbzXuIE0b
 github.com/juju/loggo v0.0.0-20190526231331-6e530bcce5d8/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/juju/testing v0.0.0-20190613124551-e81189438503/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/kennygrant/sanitize v1.2.4 h1:gN25/otpP5vAsO2djbMhF/LQX6R7+O1TB4yv8NzpJ3o=
+github.com/kennygrant/sanitize v1.2.4/go.mod h1:LGsjYYtgxbetdg5owWB2mpgUL6e2nfw2eObZ0u0qvak=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v0.0.0-20161130080628-0de1eaf82fa3/go.mod h1:jxZFDH7ILpTPQTk+E2s+z4CUas9lVNjIuKR4c5/zKgM=


### PR DESCRIPTION
For packages
- Removes extension .vorteil and calls the basename of the file
For projects
-Basename of the filepath is the vm name
For URLs
- check if apps.vorteil.io and parses the path to get bucket-app-version
- if not apps.vorteil.io will name the vm vorteil-vm

Every name will end up with a random hash on the end