### PR TITLE
Change the way the disk is built when running firecracker

### DIFF
--- a/cmd/vorteil/virtualizers.go
+++ b/cmd/vorteil/virtualizers.go
@@ -24,7 +24,7 @@ import (
 
 // buildFirecracker does the same thing as vdisk.Build but it returns me a calver of the kernel being used
 func buildFirecracker(ctx context.Context, w io.WriteSeeker, cfg *vcfg.VCFG, args *vdisk.BuildArgs) (string, error) {
-	vimgBuilder, err := vimg.NewBuilder(ctx, &vimg.BuilderArgs{
+	vimgBuilder, err := vdisk.CreateBuilder(ctx, &vimg.BuilderArgs{
 		Kernel: vimg.KernelOptions{
 			Shell: args.KernelOptions.Shell,
 		},

--- a/pkg/vdisk/build.go
+++ b/pkg/vdisk/build.go
@@ -22,7 +22,7 @@ type KernelOptions struct {
 	Shell bool
 }
 
-// BuildArgs conains all arguments a caller can use to customize the behaviour
+// BuildArgs contains all arguments a caller can use to customize the behaviour
 // of the Build function.
 type BuildArgs struct {
 	PackageReader vpkg.Reader
@@ -32,7 +32,8 @@ type BuildArgs struct {
 	Logger        elog.View
 }
 
-func negotiateSize(ctx context.Context, vimgBuilder *vimg.Builder, cfg *vcfg.VCFG, args *BuildArgs) error {
+// NegotiateSize prebuilds the minimum amount for a disk.
+func NegotiateSize(ctx context.Context, vimgBuilder *vimg.Builder, cfg *vcfg.VCFG, args *BuildArgs) error {
 	size := vimgBuilder.MinimumSize()
 	if !cfg.VM.DiskSize.IsDelta() {
 		if size > int64(cfg.VM.DiskSize.Units(vcfg.Byte)) {
@@ -83,12 +84,12 @@ func build(ctx context.Context, w io.WriteSeeker, cfg *vcfg.VCFG, args *BuildArg
 
 	vimgBuilder.SetDefaultMTU(args.Format.DefaultMTU())
 
-	err = negotiateSize(ctx, vimgBuilder, cfg, args)
+	err = NegotiateSize(ctx, vimgBuilder, cfg, args)
 	if err != nil {
 		return err
 	}
 
-	err = args.Format.build(ctx, w, vimgBuilder, cfg)
+	err = args.Format.Build(ctx, w, vimgBuilder, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/vdisk/build.go
+++ b/pkg/vdisk/build.go
@@ -62,11 +62,20 @@ func NegotiateSize(ctx context.Context, vimgBuilder *vimg.Builder, cfg *vcfg.VCF
 
 }
 
+// CreateBuilder creates a vimg.Builder with args provided.
+func CreateBuilder(ctx context.Context, args *vimg.BuilderArgs) (*vimg.Builder, error) {
+	vimgBuilder, err := vimg.NewBuilder(ctx, args)
+	if err != nil {
+		return nil, err
+	}
+	return vimgBuilder, nil
+}
+
 func build(ctx context.Context, w io.WriteSeeker, cfg *vcfg.VCFG, args *BuildArgs) error {
 
 	log := args.Logger
 
-	vimgBuilder, err := vimg.NewBuilder(ctx, &vimg.BuilderArgs{
+	vimgBuilder, err := CreateBuilder(ctx, &vimg.BuilderArgs{
 		Kernel: vimg.KernelOptions{
 			Shell: args.KernelOptions.Shell,
 		},

--- a/pkg/vdisk/formats.go
+++ b/pkg/vdisk/formats.go
@@ -163,7 +163,7 @@ func (x *Format) DefaultMTU() uint {
 	return defaultMTUs[*x]
 }
 
-// Builds the disk to the appropriate format ...
+// Build creates the disk for the correct format ...
 func (x *Format) Build(ctx context.Context, w io.WriteSeeker, b *vimg.Builder, cfg *vcfg.VCFG) error {
 
 	w, err := buildFuncs[*x](w, b, cfg)

--- a/pkg/vdisk/formats.go
+++ b/pkg/vdisk/formats.go
@@ -163,7 +163,8 @@ func (x *Format) DefaultMTU() uint {
 	return defaultMTUs[*x]
 }
 
-func (x *Format) build(ctx context.Context, w io.WriteSeeker, b *vimg.Builder, cfg *vcfg.VCFG) error {
+// Builds the disk to the appropriate format ...
+func (x *Format) Build(ctx context.Context, w io.WriteSeeker, b *vimg.Builder, cfg *vcfg.VCFG) error {
 
 	w, err := buildFuncs[*x](w, b, cfg)
 	if err != nil {

--- a/pkg/vimg/builder.go
+++ b/pkg/vimg/builder.go
@@ -168,6 +168,11 @@ func (b *Builder) Close() error {
 
 }
 
+// KernelUsed returns the calver the disk was built with
+func (b *Builder) KernelUsed() vkern.CalVer {
+	return b.kernel
+}
+
 // MinimumSize returns the minimum number of bytes that are needed to build the
 // image.
 func (b *Builder) MinimumSize() int64 {


### PR DESCRIPTION
By splitting up the steps I am able to retrieve the CalVer of the kernel so we can accurately fetch the right vmlinux binary when using firecracker.

Resolves #45 