### PR TITLE
Download source & Kernel arguments changed

### DIFF
--- a/pkg/virtualizers/firecracker/util_linux.go
+++ b/pkg/virtualizers/firecracker/util_linux.go
@@ -244,7 +244,7 @@ func (o *operation) createFileAndGetLength(kernel string, client *http.Client, u
 	if err != nil {
 		return nil, 0, err
 	}
-	defer file.Close()
+	// defer file.Close()
 
 	length, err := o.fetchLength(file, client, url, kernel)
 	if err != nil {
@@ -293,7 +293,7 @@ func (o *operation) fetchVMLinux(kernel string) (string, error) {
 			os.Remove(file.Name())
 			return "", err
 		}
-
+		defer file.Close()
 	}
 
 	return filepath.Join(o.firecrackerPath, kernel), nil

--- a/pkg/virtualizers/firecracker/virtualizer_linux.go
+++ b/pkg/virtualizers/firecracker/virtualizer_linux.go
@@ -407,6 +407,7 @@ func (o *operation) initializeVM(args *virtualizers.PrepareArgs) error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/pkg/virtualizers/firecracker/virtualizer_linux.go
+++ b/pkg/virtualizers/firecracker/virtualizer_linux.go
@@ -484,7 +484,7 @@ func (o *operation) generateFirecrackerConfig(diskpath string) (firecracker.Conf
 	return firecracker.Config{
 			SocketPath:      filepath.Join(o.folder, fmt.Sprintf("%s.%s", o.name, "socket")),
 			KernelImagePath: o.kip,
-			KernelArgs:      fmt.Sprintf("init=/vorteil/vinitd root=PARTUUID=%s reboot=k panic=1 pci=off vt.color=0x00", vimg.Part2UUIDString),
+			KernelArgs:      fmt.Sprintf("loglevel=4 init=/vorteil/vinitd root=PARTUUID=%s reboot=k panic=1 pci=off vt.color=0x00", vimg.Part2UUIDString),
 			Drives:          devices,
 			MachineCfg: models.MachineConfiguration{
 				VcpuCount:  firecracker.Int64(int64(o.config.VM.CPUs)),

--- a/pkg/virtualizers/firecracker/virtualizer_notlinux.go
+++ b/pkg/virtualizers/firecracker/virtualizer_notlinux.go
@@ -17,11 +17,14 @@ import (
 )
 
 // DownloadPath is the path where we pull firecracker-vmlinux's from
-const DownloadPath = "https://storage.googleapis.com/vorteil-dl/firecracker-vmlinux/"
+const DownloadPath = "https://downloads.vorteil.io/vcli/firecracker-vmlinux/"
 
+// FetchBridgeDev fetches the bridge device used for firecracker normally 'vorteil-bridge'
 func FetchBridgeDev() error {
 	return errors.New("bridge devices for firecracker only supported on linux")
 }
+
+// SetupBridgeAndDHCPServer initializes the dhcp and bridge device
 func SetupBridgeAndDHCPServer(log elog.View) error {
 	return errors.New("firecracker init not supported on this operating system")
 }


### PR DESCRIPTION
* Changed firecracker-download source to https://downloads.vorteil.io
* Added loglevel=4 on firecracker kernel arguments
* Fixed a bug when downloading vmlinux file was closed before the copy.