### PR TITLE
conf.go constructGetLastestKernelsFunc moved to vkern/ConstructGetLas…

### DIFF
--- a/cmd/vorteil/conf.go
+++ b/cmd/vorteil/conf.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -73,20 +72,6 @@ func mkDirAllSlice(perm os.FileMode, dirs ...string) error {
 	return nil
 }
 
-func constructGetLastestKernelsFunc(ksrc vkern.Manager) func(ctx context.Context) (vkern.CalVer, error) {
-	return func(ctx context.Context) (vkern.CalVer, error) {
-		s, err := ksrc.Latest()
-		if err != nil {
-			return vkern.CalVer(""), err
-		}
-		k, err := vkern.Parse(s)
-		if err != nil {
-			return vkern.CalVer(""), err
-		}
-		return k, nil
-	}
-}
-
 func initKernels() error {
 	vCfg, err := loadVorteilConfig()
 	if err != nil {
@@ -109,7 +94,7 @@ func initKernels() error {
 
 	vkern.Global = ksrc
 	vimg.GetKernel = ksrc.Get
-	vimg.GetLatestKernel = constructGetLastestKernelsFunc(ksrc)
+	vimg.GetLatestKernel = vkern.ConstructGetLastestKernelsFunc(&ksrc)
 
 	return nil
 

--- a/pkg/vkern/manager.go
+++ b/pkg/vkern/manager.go
@@ -138,6 +138,21 @@ type Manager interface {
 	Latest() (string, error)
 }
 
+// ConstructGetLastestKernelsFunc : Given a Kernel Manager will construct a function that returns the latest Kernel Version
+func ConstructGetLastestKernelsFunc(ksrc *Manager) func(ctx context.Context) (CalVer, error) {
+	return func(ctx context.Context) (CalVer, error) {
+		s, err := (*ksrc).Latest()
+		if err != nil {
+			return CalVer(""), err
+		}
+		k, err := Parse(s)
+		if err != nil {
+			return CalVer(""), err
+		}
+		return k, nil
+	}
+}
+
 // Utils
 func removeFiles(files ...string) error {
 	for _, fPath := range files {


### PR DESCRIPTION
…testKernelsFunc

## Description

moved constructGetLastestKernelsFunc to vkern package

## Purpose

- [x] Other
