### PR TITLE
Fixed bug that was causing a panic, due to trying to assign a value t…

### DIFF
--- a/cmd/vorteil/vcfg-flags.go
+++ b/cmd/vorteil/vcfg-flags.go
@@ -247,6 +247,11 @@ var networkGatewayFlagValidator = func(f flag.NStringFlag) error {
 
 var networkFlagValidator = func(f flag.NStringSliceFlag, fn func(nic *vcfg.NetworkInterface, s interface{})) error {
 	for i := 0; i < *f.Total; i++ {
+		// Skip empty values from unassigned flags
+		if f.Value[i] == nil {
+			continue
+		}
+
 		initRequiredNetworks(len(f.Value[i]), i)
 		s := f.Value[i]
 		nic := &overrideVCFG.Networks[i]


### PR DESCRIPTION
…o an empty overrideVCFG network array

## Purpose

- [x] Bug fix
- [ ] New feature
- [ ] Other

## How was this tested? (if applicable)

Tested on my local MX Linux machine.