### PR TITLE
changed the firecracker download dir

### DIFF
--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -220,7 +220,7 @@ func run(virt virtualizers.Virtualizer, diskpath string, cfg *vcfg.VCFG, name st
 		PName:     virt.Type(),
 		Start:     true,
 		Config:    cfg,
-		FCPath:    filepath.Join(home, ".vorteild", "firecracker-vm"),
+		FCPath:    filepath.Join(home, ".vorteil", "firecracker-vm"),
 		ImagePath: diskpath,
 		Logger:    log,
 	})


### PR DESCRIPTION
Signed-off-by: Jens Gerke <jens.gerke@vorteil.io>

## Description

Changing the firecracker download dir from .vorteild to .vorteil to use the same folder like the cli kernels

## Purpose

- [ ] Bug fix
- [ ] New feature
- [x] Other