### PR TITLE
fix: hostname ending with - (#96)

### DIFF
--- a/pkg/vcfg/defaults.go
+++ b/pkg/vcfg/defaults.go
@@ -57,5 +57,5 @@ func sanitizeHostname(s string) string {
 	if x == nil {
 		return "vorteil"
 	}
-	return strings.Join(x, "")
+	return strings.Trim(strings.Join(x, ""), "-")
 }


### PR DESCRIPTION
## Description

Fix issue #96 by ensuring no trailing '-' occurs for 'sanitized' / generated hostnames.

## Purpose

- [x] Bug fix
- [ ] New feature
- [ ] Other
