### PR TITLE
fix: remove leading 0 from gcpTarPosixHeader.Size when creating gcp d…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ jobs:
         - if [ ! -z "$TRAVIS_TAG" ]; then export BUILD_TAG=$TRAVIS_TAG; else export BUILD_TAG=0.0.0; fi;
         - export BUILD_DATE=$(date '+%a, %d %b %Y %H:%M:%S %z')
         - export BUILD_REF=$(git rev-parse --short HEAD)
-        - export LDFLAGS="-X main.release=$BUILD_TAG -X main.commit=$BUILD_REF -X 'main.date=$BUILD_DATE'"
+        - export LDFLAGS="-X github.com/vorteil/vorteil/pkg/cli.release=$BUILD_TAG -X github.com/vorteil/vorteil/pkg/cli.commit=$BUILD_REF -X 'github.com/vorteil/vorteil/pkg/cli.date=$BUILD_DATE'"
         - echo $LDFLAGS
         - go build -o vorteil -ldflags "$LDFLAGS" github.com/vorteil/vorteil/cmd/vorteil
         - if [ "$TRAVIS_EVENT_TYPE" != "pull_request" ] && [ ! -z "$TRAVIS_TAG" ]; then codesign --sign "$OSX_APP_SIGN_ID" -v --timestamp --options runtime vorteil; fi;

--- a/pkg/gcparchive/gcparchive.go
+++ b/pkg/gcparchive/gcparchive.go
@@ -53,7 +53,7 @@ func NewWriter(w io.Writer, h Sizer) (*Writer, error) {
 func (w *Writer) writeHeader() error {
 	header := new(gcpTarPosixHeader)
 	copy(header.Name[:], []byte("disk.raw")) // gcp requires the file is called disk.raw
-	octal := "0" + strconv.FormatUint(uint64(w.length), 8)
+	octal := strconv.FormatUint(uint64(w.length), 8)
 	copy(header.Size[:], []byte(octal))
 	header.Mode = [8]byte{0x30, 0x30, 0x30, 0x30, 0x36, 0x34, 0x34, 0x00}
 	copy(header.Mtime[:], []byte("00000000000"))

--- a/pkg/gcparchive/gcparchive.go
+++ b/pkg/gcparchive/gcparchive.go
@@ -8,6 +8,7 @@ package gcparchive
 import (
 	"bytes"
 	"errors"
+	"fmt"
 
 	// "compress/gzip"
 	"encoding/binary"
@@ -54,6 +55,12 @@ func (w *Writer) writeHeader() error {
 	header := new(gcpTarPosixHeader)
 	copy(header.Name[:], []byte("disk.raw")) // gcp requires the file is called disk.raw
 	octal := strconv.FormatUint(uint64(w.length), 8)
+
+	// header.Size field has len of 12 bytes
+	if len(octal) > 12 {
+		return fmt.Errorf("disk size is too large (must be <= 68719476735 bytes)")
+	}
+
 	copy(header.Size[:], []byte(octal))
 	header.Mode = [8]byte{0x30, 0x30, 0x30, 0x30, 0x36, 0x34, 0x34, 0x00}
 	copy(header.Mtime[:], []byte("00000000000"))


### PR DESCRIPTION
fix: remove leading 0 from gcpTarPosixHeader.Size when creating gcp disk images

## Description

Fix #100 
Removes leading 0 from the gcpTarPosixHeader.Size field. 

## Purpose

- [x] Bug fix
- [ ] New feature
- [ ] Other

## How was this tested? (if applicable)

Provisioned and ran instances on Google Cloud with `vm.disk-size` set to 1GiB and 10GiB.
