### PR TITLE
set modTime to 0 and dir size to 0 when marshalling filetree json

### DIFF
--- a/pkg/vio/tree.go
+++ b/pkg/vio/tree.go
@@ -146,13 +146,18 @@ func (n *TreeNode) MarshalJSON() ([]byte, error) {
 		return nil, fmt.Errorf("failed to marshal JSON due to broken tree node: '%s' has size '%d'", n.path(), n.File.Size())
 	}
 
+	size := n.File.Size()
+	if n.File.IsDir() {
+		size = 0
+	}
+
 	m := make(map[string]interface{})
 	info := &fi{
 		Name:      n.File.Name(),
-		Size:      n.File.Size(),
+		Size:      size,
 		IsDir:     n.File.IsDir(),
 		IsSymlink: n.File.IsSymlink(),
-		ModTime:   n.File.ModTime(),
+		ModTime:   time.Time{},
 	}
 
 	if n.File.IsSymlink() && n.File.SymlinkIsCached() {


### PR DESCRIPTION
Signed-off-by: James <james.murtagh@vorteil.io>

## Description

Set the modtime of files in (`pkg/vio/tree.go`) `(*TreeNode).MarshalJSON` function to `time.Time{}`. Also set size to 0 if file is a directory.

## Purpose

- [x] Bug fix
- [ ] New feature
- [ ] Other

Allows for reproducible package refs from the same source.
