### PR TITLE
Sig vcfg

### DIFF
--- a/pkg/cli/vcfg-flags.go
+++ b/pkg/cli/vcfg-flags.go
@@ -365,7 +365,7 @@ var systemUserFlagValidator = func(f flag.StringFlag) error {
 }
 
 // --system.terminate-wait
-var systemTerminateWaitFlag = flag.NewUintFlag("system.terminate-wait", "how long to wait after sending signal on program termination", hideFlags, ssystemTerminateWaitFlagValidator)
+var systemTerminateWaitFlag = flag.NewUintFlag("system.terminate-wait", "how many milliseconds to wait for program termination (default: 3000)", hideFlags, ssystemTerminateWaitFlagValidator)
 var ssystemTerminateWaitFlagValidator = func(f flag.UintFlag) error {
 	overrideVCFG.System.TerminateWait = f.Value
 	return nil
@@ -507,7 +507,7 @@ var programCWDFlagValidator = func(f flag.NStringFlag) error {
 }
 
 // --program.terminate
-var programTerminateFlag = flag.NewNStringFlag("program[<<N>>].terminate", "configure the signal to send program on termination", &maxProgramFlags, hideFlags, programTerminateFlagValidator)
+var programTerminateFlag = flag.NewNStringFlag("program[<<N>>].terminate", "configure the signal to send program on termination (default: SIGTERM)", &maxProgramFlags, hideFlags, programTerminateFlagValidator)
 var programTerminateFlagValidator = func(f flag.NStringFlag) error {
 	return initRequiredProgramsFromString(f, func(prog *vcfg.Program, s string) { prog.Terminate = vcfg.TerminateSignal(s) })
 }

--- a/pkg/cli/vcfg-flags.go
+++ b/pkg/cli/vcfg-flags.go
@@ -365,8 +365,8 @@ var systemUserFlagValidator = func(f flag.StringFlag) error {
 }
 
 // --system.terminate-wait
-var systemTerminateWaitFlag = flag.NewStringFlag("system.terminate-wait", "how long to wait after sending signal on program termination", hideFlags, systemUserFlagValidator)
-var ssystemTerminateWaitFlagValidator = func(f flag.StringFlag) error {
+var systemTerminateWaitFlag = flag.NewUintFlag("system.terminate-wait", "how long to wait after sending signal on program termination", hideFlags, ssystemTerminateWaitFlagValidator)
+var ssystemTerminateWaitFlagValidator = func(f flag.UintFlag) error {
 	overrideVCFG.System.TerminateWait = f.Value
 	return nil
 }

--- a/pkg/cli/vcfg-flags.go
+++ b/pkg/cli/vcfg-flags.go
@@ -561,4 +561,5 @@ var vcfgFlags = flag.FlagsList{
 	&programPrivilegesFlag, &programArgsFlag, &programStdoutFlag,
 	&programStderrFlag, &programLogFilesFlag, &programBootstrapFlag,
 	&programEnvFlag, &programCWDFlag, &programStraceFlag, &sysctlFlag,
+	&programTerminateFlag, &systemTerminateWaitFlag,
 }

--- a/pkg/cli/vcfg-flags.go
+++ b/pkg/cli/vcfg-flags.go
@@ -365,8 +365,8 @@ var systemUserFlagValidator = func(f flag.StringFlag) error {
 }
 
 // --system.terminate-wait
-var systemTerminateWaitFlag = flag.NewUintFlag("system.terminate-wait", "how many milliseconds to wait for program termination (default: 3000)", hideFlags, ssystemTerminateWaitFlagValidator)
-var ssystemTerminateWaitFlagValidator = func(f flag.UintFlag) error {
+var systemTerminateWaitFlag = flag.NewUintFlag("system.terminate-wait", "how many milliseconds to wait for program termination (default: 3000)", hideFlags, systemTerminateWaitFlagValidator)
+var systemTerminateWaitFlagValidator = func(f flag.UintFlag) error {
 	overrideVCFG.System.TerminateWait = f.Value
 	return nil
 }

--- a/pkg/cli/vcfg-flags.go
+++ b/pkg/cli/vcfg-flags.go
@@ -357,10 +357,17 @@ var systemOutputModeFlagValidator = func(f flag.StringFlag) error {
 	return nil
 }
 
-// -- system.user
+// --system.user
 var systemUserFlag = flag.NewStringFlag("system.user", "name of the non-root user (default: vorteil)", hideFlags, systemUserFlagValidator)
 var systemUserFlagValidator = func(f flag.StringFlag) error {
 	overrideVCFG.System.User = f.Value
+	return nil
+}
+
+// --system.terminate-wait
+var systemTerminateWaitFlag = flag.NewStringFlag("system.terminate-wait", "how long to wait after sending signal on program termination", hideFlags, systemUserFlagValidator)
+var ssystemTerminateWaitFlagValidator = func(f flag.StringFlag) error {
+	overrideVCFG.System.TerminateWait = f.Value
 	return nil
 }
 
@@ -497,6 +504,12 @@ var programEnvFlagValidator = func(f flag.NStringSliceFlag) error {
 var programCWDFlag = flag.NewNStringFlag("program[<<N>>].cwd", "configure the working directory of a program", &maxProgramFlags, hideFlags, programCWDFlagValidator)
 var programCWDFlagValidator = func(f flag.NStringFlag) error {
 	return initRequiredProgramsFromString(f, func(prog *vcfg.Program, s string) { prog.Cwd = s })
+}
+
+// --program.terminate
+var programTerminateFlag = flag.NewNStringFlag("program[<<N>>].terminate", "configure the signal to send program on termination", &maxProgramFlags, hideFlags, programTerminateFlagValidator)
+var programTerminateFlagValidator = func(f flag.NStringFlag) error {
+	return initRequiredProgramsFromString(f, func(prog *vcfg.Program, s string) { prog.Terminate = vcfg.TerminateSignal(s) })
 }
 
 // --program.logfiles

--- a/pkg/cli/vcfg-flags_test.go
+++ b/pkg/cli/vcfg-flags_test.go
@@ -557,6 +557,20 @@ func TestSystemMaxFDsFlag(t *testing.T) {
 
 }
 
+func TestSystemTerminateWaitFlag(t *testing.T) {
+
+	testResetOverrideVCFG()
+
+	// set --system.terminate-wait="1000"
+	f := systemTerminateWaitFlag
+	f.Value = 1000
+
+	err := systemTerminateWaitFlagValidator(f)
+	assert.NoError(t, err)
+	assert.Equal(t, f.Value, overrideVCFG.System.TerminateWait)
+
+}
+
 func TestSystemOutputModeFlag(t *testing.T) {
 
 	testResetOverrideVCFG()
@@ -718,6 +732,23 @@ func TestProgramsCWDFlag(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, nProgs, len(overrideVCFG.Programs))
 	assert.Equal(t, f.Value[1], overrideVCFG.Programs[1].Cwd)
+
+}
+
+func TestProgramsTerminateFlag(t *testing.T) {
+
+	testResetOverrideVCFG()
+
+	// set --program[2].terminate="SIGTERM"
+	f := programTerminateFlag
+	f.Value = []string{"", "SIGTERM"}
+	nProgs := 2
+	f.Total = &nProgs
+
+	err := programTerminateFlagValidator(f)
+	assert.NoError(t, err)
+	assert.Equal(t, nProgs, len(overrideVCFG.Programs))
+	assert.Equal(t, f.Value[1], string(overrideVCFG.Programs[1].Terminate))
 
 }
 

--- a/pkg/vcfg/bootstrap.go
+++ b/pkg/vcfg/bootstrap.go
@@ -5,6 +5,7 @@ package vcfg
  * Copyright 2020 vorteil.io Pty Ltd
  */
 
+// Command ...
 type Command string
 
 // Bootstrap commands

--- a/pkg/vcfg/defaults.go
+++ b/pkg/vcfg/defaults.go
@@ -47,6 +47,16 @@ func WithDefaults(v *VCFG, logger elog.View) error {
 		logger.Debugf("Setting empty hostname field to '%s'", v.System.Hostname)
 	}
 
+	for i := range v.Programs {
+		if v.Programs[i].Terminate == "" {
+			v.Programs[i].Terminate = DefaultTerminateSignal
+		}
+	}
+
+	if v.System.TerminateWait == 0 {
+		v.System.TerminateWait = 3000
+	}
+
 	return nil
 }
 

--- a/pkg/vcfg/merge_test.go
+++ b/pkg/vcfg/merge_test.go
@@ -164,6 +164,7 @@ func TestMergePrograms(t *testing.T) {
 	assert.Equal(t, replacementProgram.Strace, a.Programs[0].Strace)
 	assert.Equal(t, replacementProgram.Cwd, a.Programs[0].Cwd)
 	assert.Equal(t, replacementProgram.Args, a.Programs[0].Args)
+	assert.Equal(t, replacementProgram.Terminate, a.Programs[0].Terminate)
 
 }
 

--- a/pkg/vcfg/signals.go
+++ b/pkg/vcfg/signals.go
@@ -44,3 +44,12 @@ func (tSig *TerminateSignal) Validate() (err error) {
 
 	return fmt.Errorf("terminate signal '%s' is not supported. Supported Signals: %s", *tSig, validSignals)
 }
+
+// Signal : Return syscall Signal
+func (tSig *TerminateSignal) Signal() (syscall.Signal, error) {
+	if err := tSig.Validate(); err != nil {
+		return syscall.Signal(0), err
+	}
+
+	return TerminateSignals[*tSig], nil
+}

--- a/pkg/vcfg/signals.go
+++ b/pkg/vcfg/signals.go
@@ -1,0 +1,41 @@
+package vcfg
+
+import (
+	"fmt"
+)
+
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2020 vorteil.io Pty Ltd
+ */
+
+//TerminateSignal : The Signal to send to a program on termination
+//	Additional information can be found @ https://support.vorteil.io/docs/VCFG-Reference/program/terminate
+type TerminateSignal string
+
+// TerminateSignals : Supported Signals
+var TerminateSignals = []TerminateSignal{
+	"SIGINT",  // Term    Interrupt from keyboard
+	"SIGKILL", // Term    Kill signal
+	"SIGPWR",  // Term    Power failure (System V)
+	"SIGQUIT", // Core    Quit from keyboard
+	"SIGSTOP", // Stop    Stop process
+	"SIGTERM", // Term    Termination signal
+}
+
+// Validate TerminateSignal
+func (tSig *TerminateSignal) Validate() (err error) {
+	validSignals := ""
+	for i := range TerminateSignals {
+		validSignals += string(TerminateSignals[i])
+		if len(TerminateSignals)-1 != i {
+			validSignals += ", "
+		}
+
+		if *tSig == TerminateSignals[i] {
+			return
+		}
+	}
+
+	return fmt.Errorf("terminate signal '%s' is not supported. Supported Signals: %s", *tSig, validSignals)
+}

--- a/pkg/vcfg/signals.go
+++ b/pkg/vcfg/signals.go
@@ -2,6 +2,7 @@ package vcfg
 
 import (
 	"fmt"
+	"strings"
 	"syscall"
 )
 
@@ -27,25 +28,19 @@ var TerminateSignals = map[TerminateSignal]syscall.Signal{
 	"SIGTERM": syscall.SIGTERM, // Term    Termination signal
 }
 
-// Validate TerminateSignal
+// Validate : Check if TerminateSignal is a supported signal
 func (tSig *TerminateSignal) Validate() (err error) {
-	validSignals := ""
-	i := 0
-	for strSig := range TerminateSignals {
-		validSignals += string(strSig)
+	validSignals := make([]string, 0)
 
-		if i < len(TerminateSignals)-1 {
-			validSignals += ", "
-		}
-
-		if *tSig == strSig {
-			return
-		}
-
-		i++
+	if _, ok := TerminateSignals[*tSig]; ok {
+		return // Valid Signal
 	}
 
-	return fmt.Errorf("terminate signal '%s' is not supported. Supported Signals: %s", *tSig, validSignals)
+	for strSig := range TerminateSignals {
+		validSignals = append(validSignals, string(strSig))
+	}
+
+	return fmt.Errorf("terminate signal '%s' is not supported. Supported Signals: %s", *tSig, strings.Join(validSignals, ", "))
 }
 
 // Signal : Return syscall Signal

--- a/pkg/vcfg/signals.go
+++ b/pkg/vcfg/signals.go
@@ -2,6 +2,7 @@ package vcfg
 
 import (
 	"fmt"
+	"syscall"
 )
 
 /**
@@ -14,27 +15,31 @@ import (
 type TerminateSignal string
 
 // TerminateSignals : Supported Signals
-var TerminateSignals = []TerminateSignal{
-	"SIGINT",  // Term    Interrupt from keyboard
-	"SIGKILL", // Term    Kill signal
-	"SIGPWR",  // Term    Power failure (System V)
-	"SIGQUIT", // Core    Quit from keyboard
-	"SIGSTOP", // Stop    Stop process
-	"SIGTERM", // Term    Termination signal
+var TerminateSignals = map[TerminateSignal]syscall.Signal{
+	"SIGINT":  syscall.SIGINT,  // Term    Interrupt from keyboard
+	"SIGKILL": syscall.SIGKILL, // Term    Kill signal
+	"SIGPWR":  syscall.SIGPWR,  // Term    Power failure (System V)
+	"SIGQUIT": syscall.SIGQUIT, // Core    Quit from keyboard
+	"SIGSTOP": syscall.SIGSTOP, // Stop    Stop process
+	"SIGTERM": syscall.SIGTERM, // Term    Termination signal
 }
 
 // Validate TerminateSignal
 func (tSig *TerminateSignal) Validate() (err error) {
 	validSignals := ""
-	for i := range TerminateSignals {
-		validSignals += string(TerminateSignals[i])
-		if len(TerminateSignals)-1 != i {
+	i := 0
+	for strSig := range TerminateSignals {
+		validSignals += string(strSig)
+
+		if i < len(TerminateSignals)-1 {
 			validSignals += ", "
 		}
 
-		if *tSig == TerminateSignals[i] {
+		if *tSig == strSig {
 			return
 		}
+
+		i++
 	}
 
 	return fmt.Errorf("terminate signal '%s' is not supported. Supported Signals: %s", *tSig, validSignals)

--- a/pkg/vcfg/signals.go
+++ b/pkg/vcfg/signals.go
@@ -14,6 +14,9 @@ import (
 //	Additional information can be found @ https://support.vorteil.io/docs/VCFG-Reference/program/terminate
 type TerminateSignal string
 
+// DefaultTerminateSignal : Default Terminate Signal to be used on programs
+const DefaultTerminateSignal TerminateSignal = "SIGTERM"
+
 // TerminateSignals : Supported Signals
 var TerminateSignals = map[TerminateSignal]syscall.Signal{
 	"SIGINT":  syscall.SIGINT,  // Term    Interrupt from keyboard

--- a/pkg/vcfg/vcfg.go
+++ b/pkg/vcfg/vcfg.go
@@ -99,7 +99,7 @@ type SystemSettings struct {
 	KernelArgs    string     `toml:"kernel-args,omitempty" json:"kernel-args,omitempty"`
 	Filesystem    Filesystem `toml:"filesystem,omitempty" json:"filesystem,omitempty"`
 	User          string     `toml:"user,omitempty" json:"user,omitempty"` // Note: should we validate against regex ^[a-z]*$
-	TerminateWait uint       `toml:"terminate-wait,omitempty" json:"terminate-wait,omitempty"`
+	TerminateWait uint       `toml:"terminate-wait,omitzero" json:"terminate-wait,omitzero"`
 }
 
 // PackageInfo ..

--- a/pkg/vcfg/vcfg.go
+++ b/pkg/vcfg/vcfg.go
@@ -99,7 +99,7 @@ type SystemSettings struct {
 	KernelArgs    string     `toml:"kernel-args,omitempty" json:"kernel-args,omitempty"`
 	Filesystem    Filesystem `toml:"filesystem,omitempty" json:"filesystem,omitempty"`
 	User          string     `toml:"user,omitempty" json:"user,omitempty"` // Note: should we validate against regex ^[a-z]*$
-	TerminateWait string     `toml:"terminate-wait,omitempty" json:"terminate-wait,omitempty"`
+	TerminateWait uint       `toml:"terminate-wait,omitempty" json:"terminate-wait,omitempty"`
 }
 
 // PackageInfo ..

--- a/pkg/vcfg/vcfg.go
+++ b/pkg/vcfg/vcfg.go
@@ -48,16 +48,17 @@ var (
 
 // Program ..
 type Program struct {
-	Binary    string    `toml:"binary,omitempty" json:"binary"`
-	Args      string    `toml:"args,omitempty" json:"args"`
-	Env       []string  `toml:"env,omitempty" json:"env"`
-	Cwd       string    `toml:"cwd,omitempty" json:"cwd"`
-	Stdout    string    `toml:"stdout,omitempty" json:"stdout"`
-	Stderr    string    `toml:"stderr,omitempty" json:"stderr"`
-	Bootstrap []string  `toml:"bootstrap,ommitempty" json:"bootstrap"`
-	LogFiles  []string  `toml:"logfiles,omitempty" json:"logfiles"`
-	Privilege Privilege `toml:"privilege,omitempty" json:"privilege"`
-	Strace    bool      `toml:"strace,omitempty" json:"strace"`
+	Binary    string          `toml:"binary,omitempty" json:"binary"`
+	Args      string          `toml:"args,omitempty" json:"args"`
+	Env       []string        `toml:"env,omitempty" json:"env"`
+	Cwd       string          `toml:"cwd,omitempty" json:"cwd"`
+	Stdout    string          `toml:"stdout,omitempty" json:"stdout"`
+	Stderr    string          `toml:"stderr,omitempty" json:"stderr"`
+	Bootstrap []string        `toml:"bootstrap,ommitempty" json:"bootstrap"`
+	LogFiles  []string        `toml:"logfiles,omitempty" json:"logfiles"`
+	Privilege Privilege       `toml:"privilege,omitempty" json:"privilege"`
+	Strace    bool            `toml:"strace,omitempty" json:"strace"`
+	Terminate TerminateSignal `toml:"terminate,omitempty" json:"terminate"`
 }
 
 // NetworkInterface ..
@@ -90,14 +91,15 @@ type Route struct {
 
 // SystemSettings ..
 type SystemSettings struct {
-	DNS        []string   `toml:"dns,omitempty" json:"dns,omitempty"`
-	NTP        []string   `toml:"ntp,omitempty" json:"ntp,omitempty"`
-	Hostname   string     `toml:"hostname,omitempty" json:"hostname,omitempty"`
-	MaxFDs     uint       `toml:"max-fds,omitzero" json:"max-fds,omitempty"`
-	StdoutMode StdoutMode `toml:"output-mode,omitzero" json:"stdout-mode,omitempty"`
-	KernelArgs string     `toml:"kernel-args,omitempty" json:"kernel-args,omitempty"`
-	Filesystem Filesystem `toml:"filesystem,omitempty" json:"filesystem,omitempty"`
-	User       string     `toml:"user,omitempty" json:"user,omitempty"` // Note: should we validate against regex ^[a-z]*$
+	DNS           []string   `toml:"dns,omitempty" json:"dns,omitempty"`
+	NTP           []string   `toml:"ntp,omitempty" json:"ntp,omitempty"`
+	Hostname      string     `toml:"hostname,omitempty" json:"hostname,omitempty"`
+	MaxFDs        uint       `toml:"max-fds,omitzero" json:"max-fds,omitempty"`
+	StdoutMode    StdoutMode `toml:"output-mode,omitzero" json:"stdout-mode,omitempty"`
+	KernelArgs    string     `toml:"kernel-args,omitempty" json:"kernel-args,omitempty"`
+	Filesystem    Filesystem `toml:"filesystem,omitempty" json:"filesystem,omitempty"`
+	User          string     `toml:"user,omitempty" json:"user,omitempty"` // Note: should we validate against regex ^[a-z]*$
+	TerminateWait string     `toml:"terminate-wait,omitempty" json:"terminate-wait,omitempty"`
 }
 
 // PackageInfo ..

--- a/pkg/vimg/os.go
+++ b/pkg/vimg/os.go
@@ -196,6 +196,10 @@ func (b *Builder) validateConfig() error {
 
 		// TODO: validate bootstrap?
 
+		// Validate Terminate Signal
+		if err := p.Terminate.Validate(); err != nil {
+			return err
+		}
 	}
 
 	for i, n := range b.vcfg.Networks {


### PR DESCRIPTION
## Description

Adds `programs.terminate` and `system.terminate-wait` to vcfg.

## Purpose

- [ ] Bug fix
- [X] New feature
- [ ] Other

## How was this tested? (if applicable)

Tested functionality with new kernel built from https://github.com/vorteil/vinitd/tree/sig-terminate

## Test Platform Details (if applicable)

**Operating system:** Ubuntu 20.04.