### PR TITLE
Increase GCP image creation timeout from 2 minutes to 30 minutes.

### DIFF
--- a/pkg/provisioners/google/google.go
+++ b/pkg/provisioners/google/google.go
@@ -63,7 +63,7 @@ const (
 	// ProvisionerType for GCP provisioner
 	ProvisionerType = "google-compute"
 	statusDone      = "DONE"
-	waitInSecs      = 120
+	waitInSecs      = 1800 // 30 minutes
 )
 
 var scopes = []string{


### PR DESCRIPTION
## Description

Depending on the size of an image the 2-minute timeout for Google Cloud provision operations may not be generous enough. 
Increased timeout duration from 2 minutes to 30.

## Purpose

Enhancement. Resolves #127 
